### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Change Log
+
+# 0.2.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This action enables the integration of StackStorm into Microsoft PowerPoint. Thi
 
 The user can provide a corporate PowerPoint template by specifying a path in `config.yaml`
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 #### Make Presentation
 
 Input :

--- a/actions/build_presentation.yaml
+++ b/actions/build_presentation.yaml
@@ -1,5 +1,5 @@
 name: build_presentation
-runner_type: run-python
+runner_type: python-script
 description: Create a PowerPoint presentation
 enabled: true
 entry_point: build_presentation.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: powerpoint
 name: powerpoint
 description: Packs which allows integration with Microsoft Powerpoint
-version: 0.1.0
+version: 0.2.0
 author: Anthony Shaw
 email: anthonyshaw@apache.org


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.